### PR TITLE
Update netease-cloud-music-1.1.0.ebuild

### DIFF
--- a/media-sound/netease-cloud-music/netease-cloud-music-1.1.0.ebuild
+++ b/media-sound/netease-cloud-music/netease-cloud-music-1.1.0.ebuild
@@ -62,7 +62,7 @@ src_install() {
 
 	dobin ${S}/usr/bin/${PN}
 
-	fperms 0755 /usr/$(get_libdir)/${PN}/lib/*
+	#fperms 0755 /usr/$(get_libdir)/${PN}/lib/*
 
 	insinto /usr/
 	doins -r ${S}/usr/share


### PR DESCRIPTION
修复fperms语法问题引起的emerge failed，默认权限就可以运行。