### PR TITLE
Make termite ebuild EAPI=7 compliant

### DIFF
--- a/x11-terms/termite/termite-13.ebuild
+++ b/x11-terms/termite/termite-13.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=7
 
-inherit eutils toolchain-funcs versionator
+inherit eutils toolchain-funcs
 if [[ 9999 == $PV ]]; then
 	inherit git-r3
 else
@@ -30,7 +30,7 @@ RDEPEND="dev-libs/libpcre2
 DEPEND="${RDEPEND}"
 
 pkg_pretend() {
-	if ! version_is_at_least 4.7 $(gcc-version); then
+	if ! ver_test $(gcc-version) -gt 4.7; then
 		eerror "${PN} passes -std=c++11 to \${CXX} and requires a version"
 		eerror "of gcc newer than 4.7.0"
 	fi

--- a/x11-terms/termite/termite-9999.ebuild
+++ b/x11-terms/termite/termite-9999.ebuild
@@ -5,7 +5,7 @@
 
 EAPI=7
 
-inherit eutils toolchain-funcs versionator
+inherit eutils toolchain-funcs
 if [[ 9999 == $PV ]]; then
 	inherit git-r3
 else
@@ -28,7 +28,7 @@ DEPEND="${LIBDEPEND}"
 RDEPEND="${LIBDEPEND}"
 
 pkg_pretend() {
-	if ! version_is_at_least 4.7 $(gcc-version); then
+	if ! ver_test $(gcc-version) -gt 4.7; then
 		eerror "${PN} passes -std=c++11 to \${CXX} and requires a version"
 		eerror "of gcc newer than 4.7.0"
 	fi


### PR DESCRIPTION
Support for the versionator eclass was dropped in EAPI=7.  This results in big fat error messages every time portage is run. 

Fix this by removing versionator and using `ver_test` for version comparison instead.

See documentation here: https://dev.gentoo.org/~mgorny/articles/the-ultimate-guide-to-eapi-7.html#replacing-versionator-eclass-uses